### PR TITLE
Added :host, ::ng-deep, :host-context to the purgeCss whitelist

### DIFF
--- a/src/ng-add-setup/files/webpack/webpack-prod.config.js
+++ b/src/ng-add-setup/files/webpack/webpack-prod.config.js
@@ -11,11 +11,16 @@ module.exports = {
                 require("tailwindcss")("./tailwind.config.js"),
                 require("@fullhuman/postcss-purgecss")({
                   content: [
+                    "./src/index.html",
                     "./src/**/*.component.html",
                     "./src/**/*.component.ts"
                   ],
-                  defaultExtractor: content =>
-                    content.match(/[A-Za-z0-9-_:/]+/g) || []
+                  defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || [],
+                  whitelist: [
+                    ':host',
+                    '::ng-deep',
+                    ':host-context'
+                  ]
                 }),
                 require("autoprefixer")
               ]


### PR DESCRIPTION
With the current version, purgecss is purging all `:host`, `::ng-deep` and `:host-context` css in the component.scss.
This pull request fixes this behaviour by whitelisting the selectors above.
Additionally, it adds the `index.thml` to the purgecss content.

Best regards
Severin